### PR TITLE
feat: If no navigation type is given, show all categories

### DIFF
--- a/Block/Navigation.php
+++ b/Block/Navigation.php
@@ -81,11 +81,10 @@ class Navigation extends \Magento\Framework\View\Element\Template implements \Ma
      */
     public function getNavigationType()
     {
-        if ($this->getType() == \MageSuite\Navigation\Service\Navigation\Builder::TYPE_MOBILE) {
-            return \MageSuite\Navigation\Service\Navigation\Builder::TYPE_MOBILE;
+        if (empty($this->getType())) {
+            return \MageSuite\Navigation\Service\Navigation\Builder::TYPE_DESKTOP;
         }
-
-        return \MageSuite\Navigation\Service\Navigation\Builder::TYPE_DESKTOP;
+        return $this->getType();
     }
 
     /**
@@ -102,7 +101,7 @@ class Navigation extends \Magento\Framework\View\Element\Template implements \Ma
             $this->httpContext->getValue(\Magento\Customer\Model\Context::CONTEXT_AUTH)
         ];
     }
-    
+
     public function getMobileNavigationEndpointUrl()
     {
         return $this->getUrl('navigation/mobile/index');

--- a/Service/Navigation/Builder.php
+++ b/Service/Navigation/Builder.php
@@ -90,7 +90,9 @@ class Builder implements BuilderInterface
         if ($navigationType == self::TYPE_MOBILE) {
             return $category->getIncludeInMobileNavigation();
         }
-
-        return $category->getIncludeInMenu();
+        if ($navigationType == self::TYPE_DESKTOP) {
+            return $category->getIncludeInMenu();
+        }
+        return true;
     }
 }


### PR DESCRIPTION
In our shop we want to have an additional place where we can show the navigation - in the sidebar of a category's page. In contrast to the top navigation (that shows only a subset of all categories, on both desktop and mobile), in the sidebar we want to show **all** categories.

And we've already managed to do all of it by just reusing this plugin and by adding something like this to our `catalog_category_view.xml`:

```xml
    <referenceBlock name="sidebar.main">
      <block class="MageSuite\Navigation\Block\Navigation" name="category-sidebar" template="MageSuite_Navigation::category-sidebar/index.phtml" before="-">
        <arguments>
          <argument name="type" xsi:type="string">sidebar</argument>
        </arguments>
      </block>
    </referenceBlock>
```

However, this module will always show desktop-only categories by default, even if different `type` is given for the navigation block.

Why don't we make it show all categories by default? And then mobile-only and desktop-only for `mobile` and `desktop` nav types respectively?

This PR makes that possible, without the need of forking the plugin or having another plugin built on top of it.