### PR TITLE
Added missing location (tab/label) for system config

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,6 +5,8 @@
             <label>MageSuite</label>
         </tab>
         <section id="cc_frontend_extension" translate="label" type="text" sortOrder="160" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Navigation</label>
+            <tab>magesuite</tab>
             <group id="configuration" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Configuration</label>
                 <field id="sort_alphabetically" translate="label" type="select" sortOrder="10" showInDefault="1" >


### PR DESCRIPTION
The system.xml was incomplete: Label- and tab-tags were missing, so the configuration options were not displayed within the backend in the Store configuration. This pull request fixes this issue.